### PR TITLE
Updated the grammatical error and added the screenshot

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ Welcome to the Zulip community!
 The
 [Zulip community server](https://zulip.com/development-community/)
 is the primary communication forum for the Zulip community. It is a good
-place to start whether you have a question, are a new contributor, are a new
+place to start whether you have a question, are a new contributor, or a new
 user, or anything else. Please review our
 [community norms](https://zulip.com/development-community/#community-norms)
 before posting. The Zulip community is also governed by a


### PR DESCRIPTION

Here is a screenshot of the updated contributing guidelines which was having a grammatical error.

![contributing](https://user-images.githubusercontent.com/49565671/196526048-c5d9b126-b127-472a-bf25-cbf014634057.PNG)
